### PR TITLE
Bugfixes for BLE extension

### DIFF
--- a/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLE.java
+++ b/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLE.java
@@ -32,7 +32,6 @@ import com.google.appinventor.components.runtime.Form;
 import com.google.appinventor.components.runtime.util.ErrorMessages;
 import com.google.appinventor.components.runtime.util.SdkLevel;
 import com.google.appinventor.components.runtime.util.YailList;
-import com.google.common.collect.Lists;
 import gnu.lists.FString;
 
 import java.io.UnsupportedEncodingException;
@@ -52,7 +51,7 @@ import java.util.Set;
  * @author William Byrne (will2596@gmail.com) (minor bugfixes)
  */
 
-@DesignerComponent(version = 2,
+@DesignerComponent(version = 20170818,
     description = "Bluetooth Low Energy, also referred to as Bluetooth LE " +
         "or simply BLE, is a new communication protocol similar to classic Bluetooth except " +
         "that it is designed to consume less power while maintaining comparable " +
@@ -2330,6 +2329,14 @@ public class BluetoothLE extends AndroidNonvisibleComponent implements Component
       Iterator<?> i = ((YailList) value).iterator();
       i.next();  // skip *list* symbol
       return listFromIterator(tClass, i);
+    } else if (Number.class.isAssignableFrom(tClass)) {
+      if (value instanceof FString) {
+        return toList(tClass, stringToNumber(value.toString()), size);
+      } else if (! (value instanceof Collection)) {
+        return toList(tClass, Collections.singletonList(value), size);
+      } else {
+        return listFromIterator(tClass, ((Collection<?>) value).iterator());
+      }
     } else if (value instanceof FString) {  // needs to come before List
       // this assumes that the string is being cast to a list of UTF-8 bytes
       return toList(tClass, value.toString(), size);
@@ -2351,6 +2358,7 @@ public class BluetoothLE extends AndroidNonvisibleComponent implements Component
         return Collections.emptyList();
       }
     } else {
+      Log.i("BLE", "Is number assignable from " + tClass + "? " + Number.class.isAssignableFrom(tClass));
       throw new ClassCastException("Unable to convert " + value + " to list");
     }
   }
@@ -2368,11 +2376,11 @@ public class BluetoothLE extends AndroidNonvisibleComponent implements Component
   private static <T> List<T> listFromIterator(Class<T> tClass, Iterator<?> i) {
     // Primitive types cannot be cast to one another using boxed values...
     if (tClass.equals(Integer.class)) {
-      return (List<T>) toIntList((List<? extends Number>)(List) Lists.newArrayList(i));
+      return (List<T>) toIntList((List<? extends Number>)(List) newArrayList(i));
     } else if (tClass.equals(Long.class)) {
-      return (List<T>) toLongList((List<? extends Number>)(List) Lists.newArrayList(i));
+      return (List<T>) toLongList((List<? extends Number>)(List) newArrayList(i));
     } else if (tClass.equals(Float.class)) {
-      return (List<T>) toFloatList((List<? extends Number>)(List) Lists.newArrayList(i));
+      return (List<T>) toFloatList((List<? extends Number>)(List) newArrayList(i));
     }
     List<T> result = new ArrayList<T>();
     while (i.hasNext()) {
@@ -2425,6 +2433,18 @@ public class BluetoothLE extends AndroidNonvisibleComponent implements Component
       result.add((int) b);
     }
     return result;
+  }
+
+  private static <T> List<T> newArrayList(Iterator<? extends T> it) {
+    List<T> result = new ArrayList<T>();
+    while (it.hasNext()) {
+      result.add(it.next());
+    }
+    return result;
+  }
+
+  private static Number stringToNumber(String value) {
+    return Double.parseDouble(value);
   }
 }
 

--- a/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLEint.java
+++ b/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLEint.java
@@ -1682,13 +1682,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEReadByteOperation(characteristic, signed, callback));
         return null;
       }
@@ -1721,13 +1716,8 @@ final class BluetoothLEint {
         new BLEAction<Void>(METHOD) {
           @Override
           public Void action() {
-            if (!validateUUID(serviceUuid, "Service", METHOD)
-                || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-              return null;
-            }
-
-            BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-                UUID.fromString(characteristicUuid));
+            BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+                bleStringToUuid(characteristicUuid));
             schedulePendingOperation(new BLEReadByteOperation(characteristic, signed, callback, true));
             return null;
           }
@@ -1742,13 +1732,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteBytesOperation(characteristic, signed, values,
             BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE));
         return null;
@@ -1769,13 +1754,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteBytesOperation(characteristic, signed, values, BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT));
         return null;
       }
@@ -1804,13 +1784,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEReadShortOperation(characteristic, signed, callback));
         return null;
       }
@@ -1840,13 +1815,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEReadShortOperation(characteristic, signed, callback, true));
         return null;
       }
@@ -1859,13 +1829,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteShortsOperation(characteristic, signed, values,
             BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE));
         return null;
@@ -1885,13 +1850,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteShortsOperation(characteristic, signed, values,
             BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT));
         return null;
@@ -1921,13 +1881,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEReadIntegerOperation(characteristic, signed, handler));
         return null;
       }
@@ -1956,13 +1911,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEReadIntegerOperation(characteristic, signed, handler, true));
         return null;
       }
@@ -1975,13 +1925,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteIntegersOperation(characteristic, signed, values,
             BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE));
         return null;
@@ -2001,13 +1946,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteIntegersOperation(characteristic, signed, values,
             BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT));
         return null;
@@ -2038,13 +1978,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEReadFloatOperation(characteristic, shortFloat, callback));
         return null;
       }
@@ -2075,13 +2010,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEReadFloatOperation(characteristic, shortFloat, callback, true));
         return null;
       }
@@ -2094,13 +2024,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteFloatsOperation(characteristic, shortFloat, values,
             BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE));
         return null;
@@ -2120,13 +2045,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteFloatsOperation(characteristic, shortFloat, values,
             BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT));
         return null;
@@ -2195,13 +2115,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEReadStringOperation(characteristic, utf16, handler, true));
         return null;
       }
@@ -2214,13 +2129,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteStringsOperation(characteristic, utf16, values,
             BluetoothGattCharacteristic.WRITE_TYPE_NO_RESPONSE));
         return null;
@@ -2240,13 +2150,8 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        BluetoothGattCharacteristic characteristic = findMGattChar(UUID.fromString(serviceUuid),
-            UUID.fromString(characteristicUuid));
+        BluetoothGattCharacteristic characteristic = findMGattChar(bleStringToUuid(serviceUuid),
+            bleStringToUuid(characteristicUuid));
         schedulePendingOperation(new BLEWriteStringsOperation(characteristic, utf16, values,
             BluetoothGattCharacteristic.WRITE_TYPE_DEFAULT));
         return null;
@@ -2270,12 +2175,7 @@ final class BluetoothLEint {
     new BLEAction<Void>(METHOD) {
       @Override
       public Void action() {
-        if (!validateUUID(serviceUuid, "Service", METHOD)
-            || !validateUUID(characteristicUuid, "Characteristic", METHOD)) {
-          return null;
-        }
-
-        UUID characteristic = UUID.fromString(characteristicUuid);
+        UUID characteristic = bleStringToUuid(characteristicUuid);
         List<BLEOperation> operations = pendingOperationsByUuid.get(characteristic);
         if (operations != null) {
           // Copy the list to prevent ConcurrentModificationException

--- a/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLEint.java
+++ b/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLEint.java
@@ -1509,17 +1509,20 @@ final class BluetoothLEint {
 
         if (btAdapter != null) {
           mBluetoothLeDeviceScanner = btAdapter.getBluetoothLeScanner();
+
+          if (mBluetoothLeDeviceScanner != null) {
           
-          ScanSettings settings = new ScanSettings.Builder()
+            ScanSettings settings = new ScanSettings.Builder()
               .setScanMode(ScanSettings.SCAN_MODE_LOW_LATENCY)
               .build();
 
-          List<ScanFilter> filters = new ArrayList<ScanFilter>();
-          ScanFilter filter = new ScanFilter.Builder().build();
-          filters.add(filter);
+            List<ScanFilter> filters = new ArrayList<ScanFilter>();
+            ScanFilter filter = new ScanFilter.Builder().build();
+            filters.add(filter);
 
-          mBluetoothLeDeviceScanner.startScan(filters, settings, mDeviceScanCallback);
-          Log.i(LOG_TAG, "StartScanning successful.");
+            mBluetoothLeDeviceScanner.startScan(filters, settings, mDeviceScanCallback);
+            Log.i(LOG_TAG, "StartScanning successful.");
+          }
         }
 
         return null;


### PR DESCRIPTION
This PR addresses a few issues in the BLE extension:

1. Fixes a reliance on Guava that breaks in compiled apps.
2. Fixes a NPE when scanning by checking for the existence of a scanner before scanning.
3. Adds support for short UUIDs published by the Bluetooth SIG.