### PR TITLE
Add GetScannedInfo event to BLE extension

### DIFF
--- a/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLE.java
+++ b/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLE.java
@@ -43,6 +43,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Set;
 
+import android.os.Handler;
+
 
 /**
  * @author Andrew McKinney (mckinney@mit.edu)
@@ -1214,10 +1216,20 @@ public class BluetoothLE extends AndroidNonvisibleComponent implements Component
    *
    * @param rssi the strength of the received signal, from -100 to 0.
    */
+
+
+  //New Event which returns the new scanned deviceID and rssi
+  @SimpleEvent
+  public void GetScannedInfo(final String deviceID, final int rssi) {
+  }
+
+
   @SimpleEvent(description = "Trigger event when RSSI (Received Signal Strength Indicator) of found" +
       " BluetoothLE device changes")
   public void RssiChanged(final int rssi) {
   }
+
+
 
   /**
    * The <code>DeviceFound</code> event is run when a new Bluetooth low energy device is found.

--- a/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLEint.java
+++ b/appinventor/components/src/edu/mit/appinventor/ble/BluetoothLEint.java
@@ -1312,6 +1312,8 @@ final class BluetoothLEint {
           public void run() {
             isScanning = true;
             addDevice(scanResult.getDevice(), scanResult.getRssi());
+            //Call GetScannedInfo() function to trigger an event
+            GetScannedInfo(scanResult.getDevice().getAddress(), scanResult.getRssi());
           }
         });
       }
@@ -2507,6 +2509,16 @@ final class BluetoothLEint {
         }
       }
     });
+  }
+
+  //New method for positioning, which triggers GetScannedInfo event and return the deviceID and Rssi
+  private void GetScannedInfo(final String deviceID, final int device_rssi) {
+    uiThread.postDelayed(new Runnable() {
+      @Override
+      public void run() {
+        EventDispatcher.dispatchEvent(outer, "GetScannedInfo", deviceID, device_rssi);
+      }
+    }, 1000);
   }
 
   private void RssiChanged(final int device_rssi) {


### PR DESCRIPTION
Add a new event to output the new Scanned Device and Rssi.

Previously BLE just maintains a map with Device and corresponding lastest Rssi, and people could only get the whole table or get the new scanned Rssi only, without the Device ID.

